### PR TITLE
 Avoid creating a Docker layer containing the compressed model file. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM codait/max-base:v1.1.0
 ARG model_bucket=http://max-assets.s3-api.us-geo.objectstorage.softlayer.net/scene-classifier/1.0
 ARG model_file=assets.tar.gz
 
-RUN wget -nv --show-progress --progress=bar:force:noscroll  ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file}
-RUN tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
+WORKDIR /workspace
+
+RUN wget -nv --show-progress --progress=bar:force:noscroll  ${model_bucket}/${model_file} --output-document=assets/${model_file} && \
+  tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
 
 # Conda is the preferred way to install Pytorch, but the Anaconda install pulls
 # in non-OSS libraries with customized license terms, specifically CUDA and MKL.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codait/max-base:v1.1.0
+FROM codait/max-base:v1.1.1
 
 ARG model_bucket=http://max-assets.s3-api.us-geo.objectstorage.softlayer.net/scene-classifier/1.0
 ARG model_file=assets.tar.gz


### PR DESCRIPTION
Download and delete the compressed model file in the same layer to avoid an (often oversized) additional Docker layer.