### PR TITLE
[WIP] Attemp to bump MAX base version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM codait/max-base:v1.1.3
+FROM codait/max-base:v1.3.1
 
 ARG model_bucket=https://max.cdn.appdomain.cloud/max-scene-classifier/1.0.1
 ARG model_file=assets.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@
 
 FROM codait/max-base:v1.3.1
 
+RUN conda install python=3.6
+
 ARG model_bucket=https://max.cdn.appdomain.cloud/max-scene-classifier/1.0.1
 ARG model_file=assets.tar.gz
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
---find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.4.0+cpu
-torchvision==0.5.0+cpu
+torchvision==0.2.1
+http://download.pytorch.org/whl/cpu/torch-0.3.1-cp36-cp36m-linux_x86_64.whl
 pillow==6.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--find-links https://download.pytorch.org/whl/torch_stable.html
+--find-links https://download.pytorch.org/whl/torch_stable.html
 torch==1.4.0+cpu
 torchvision==0.5.0+cpu
 pillow==6.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 torchvision==0.2.1
-http://download.pytorch.org/whl/cpu/torch-0.3.1-cp37-cp37m-linux_x86_64.whl
+http://download.pytorch.org/whl/cpu/torch-0.4.1-cp37-cp37m-linux_x86_64.whl
 pillow==6.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-torchvision==0.2.1
-http://download.pytorch.org/whl/cpu/torch-0.4.1-cp37-cp37m-linux_x86_64.whl
+-find-links https://download.pytorch.org/whl/torch_stable.html
+torch==1.4.0+cpu
+torchvision==0.5.0+cpu
 pillow==6.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 torchvision==0.2.1
-http://download.pytorch.org/whl/cpu/torch-0.3.1-cp36-cp36m-linux_x86_64.whl
+http://download.pytorch.org/whl/cpu/torch-0.3.1-cp37-cp37m-linux_x86_64.whl
 pillow==6.2.1


### PR DESCRIPTION
The new MAX base uses Python 3.7. Might cause issue when combined with `assets/whole_resnet18_places365_python36.pth`